### PR TITLE
Ajout instructions AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Guide pour Codex
+
+Ce dépôt contient un plugin Paper pour Minecraft.
+
+## Exigences pour les PR
+
+- Les messages de commit doivent être en français, au présent et décrire brièvement l'action.
+- Après chaque modification, tente d'exécuter `mvn -q package` pour vérifier la compilation. Si Maven n'est pas disponible, indique-le dans la section Tests du PR.
+- Ne modifie jamais le fichier compilé `MinePlugin.jar`.
+- Respecte la structure et le style de code existants.


### PR DESCRIPTION
## Notes
- Maven n'est pas installé dans l'environnement, l'exécution de `mvn -q package` échoue.

## Summary
- ajoute un fichier `AGENTS.md` avec des consignes pour les PR