### PR TITLE
Fix Generic Armor attribute

### DIFF
--- a/src/main/java/org/example/Armure.java
+++ b/src/main/java/org/example/Armure.java
@@ -240,7 +240,7 @@ public final class Armure implements CommandExecutor, Listener {
                 wolf.setOwner(player);
                 wolf.setCustomName(ChatColor.RED + "Garde du Roi");
                 wolf.setAdult();
-                wolf.getAttribute(Attribute.ARMOR).setBaseValue(40.0);
+                wolf.getAttribute(Attribute.GENERIC_ARMOR).setBaseValue(40.0);
                 wolf.setHealth(40.0);
                 wolf.setCollarColor(DyeColor.RED);
 


### PR DESCRIPTION
## Summary
- use `Attribute.GENERIC_ARMOR` for wolves in `Armure`

## Testing
- `mvn -q package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cc5ddb9f4832e83cd60000776cd7c