### PR TITLE
MAJ plugin.yml version dynamique

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
+                <filtering>false</filtering>
             </resource>
         </resources>
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: MinePlugin
-version: 1.0
+version: ${project.version}
 main: org.example.MinePlugin
 api-version: "1.20"          # version reconnue par Spigot/Paper
 


### PR DESCRIPTION
## Notes
- Maven est indisponible (`mvn` introuvable), la compilation n'a pas pu être testée.

## Summary
- ajuste `plugin.yml` pour utiliser `${project.version}`
- désactive explicitement le filtrage des ressources dans `pom.xml`

## Testing
- `mvn -q package` *(échoue: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e4b871bf4832ea6765ee71e3d81f9