### PR TITLE
Mise à jour de l'api-version

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: MinePlugin
 version: ${project.version}
 main: org.example.MinePlugin
-api-version: "1.20"          # version reconnue par Spigot/Paper
+api-version: "1.21"          # version reconnue par Spigot/Paper
 
 commands:
   army:


### PR DESCRIPTION
## Summary
- passe l'`api-version` à `1.21` dans `plugin.yml`

## Testing
- `mvn -q package` *(échoue: `mvn` absent)*

------
https://chatgpt.com/codex/tasks/task_e_684e4c2e8bb4832ea12be0d84cf23492