### PR TITLE
Ajout de la licence MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 MineGus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -106,4 +106,8 @@ Les différentes fonctionnalités sauvegardent leurs informations dans le dossie
 - Le fichier `plugin.yml` décrivant les commandes est situé dans `src/main/resources`.
 - Des notes et idées supplémentaires sont regroupées dans `docs/IDEES.md`.
 
+## Licence
+
+Ce projet est distribué sous la licence MIT. Consultez le fichier `LICENSE` pour plus de détails.
+
 Bon jeu !


### PR DESCRIPTION
## Summary
- ajouter un fichier `LICENSE` avec le texte de la licence MIT
- indiquer la licence dans le `README`

## Testing
- `mvn -q package` *(échoue : `mvn` manquant)*

------
https://chatgpt.com/codex/tasks/task_e_684e4d461f98832e80042f7c974d1ad0