### PR TITLE
Amélioration du README pour l'utilisation en jeu

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,14 @@ Ce mod est actuellement en bêta et continuera d'évoluer. Il est développé pa
 4. Vérifiez la présence du plugin à l'aide de la commande `/plugins`.
 5. Lors du premier démarrage, un dossier `plugins/MinePlugin/` est créé pour stocker les données et configurations.
 
-## Utilisation du plugin
+## Mode en jeu
 
-Une fois le plugin chargé, vous pouvez vérifier son fonctionnement :
-1. Connectez-vous à votre serveur Minecraft.
-2. Exécutez la commande `/ping` ; le plugin devrait répondre « Pong ! ».
-3. Les autres commandes ci-dessous permettent d'automatiser différentes tâches.
+Une fois le plugin installé et le serveur relancé :
+1. Connectez-vous avec les droits d’opérateur.
+2. Tapez `/ping` pour confirmer que MinePlugin est actif.
+3. Utilisez ensuite les commandes listées plus bas pour créer vos premières zones automatisées.
+4. Pour arrêter une zone (mine, champ, forêt ou ranch), retirez tous les coffres associés.
+5. Les données sont sauvegardées dans `plugins/MinePlugin/` et restaurées au redémarrage.
 
 ## Commandes disponibles
 


### PR DESCRIPTION
## Notes
- Maven n'est pas disponible dans l'environnement, la compilation n'a pas pu être vérifiée.

## Summary
- remplacement de la section *Utilisation du plugin* par une nouvelle section *Mode en jeu*
- ajout d'explications sur la connexion, le test via `/ping`, l'arrêt des zones automatisées et la sauvegarde des données

## Testing
- `mvn -q package` *(échec: `mvn` absent)*

------
https://chatgpt.com/codex/tasks/task_e_684e52de8c74832e8aaf5dab764cdbe7