### PR TITLE
Correction dépendance MockBukkit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.seeseemelk</groupId>
-            <artifactId>MockBukkit-v1.20</artifactId>
-            <version>2.37.0</version>
+            <groupId>io.github.seeseemelk.mockbukkit</groupId>
+            <artifactId>mockbukkit-v1_20_R3</artifactId>
+            <version>2.46.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Notes
- Maven n'est pas installé dans l'environnement de test, la compilation n'a pas pu être vérifiée.

## Summary
- utilise le nouveau `groupId` et `artifactId` de MockBukkit dans `pom.xml`


------
https://chatgpt.com/codex/tasks/task_e_684e55a121e8832e858d3476a6f63754