### PR TITLE
Update Paper API version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <java.version>17</java.version>
         <!-- *** Version Paper officielle *** -->
-        <paper.api.version>1.20.4-R0.1-SNAPSHOT</paper.api.version>
+        <paper.api.version>1.21-R0.1-SNAPSHOT</paper.api.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>${java.version}</maven.compiler.release>
     </properties>


### PR DESCRIPTION
## Notes
- Unable to run Maven: `mvn` not found.

## Summary
- update `<paper.api.version>` to latest Paper 1.21

## Testing
- `mvn -q package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f1bb12bb8832ea9a22fd814cac5ac