### PR TITLE
Supprimer la référence au profil export-to-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Ce mod est actuellement en bêta et continuera d'évoluer. Il est développé pa
 1. Clonez ce dépôt puis placez-vous à la racine du projet.
 2. Exécutez `mvn clean package`.
    - Le fichier `target/MineGus-1.1-SNAPSHOT.jar` est alors généré.
-   - Vous pouvez aussi lancer `mvn clean package -P export-to-server` pour copier automatiquement l'artefact dans le dossier `plugins` défini dans `pom.xml`.
 
 ## Installation du plugin (.jar)
 


### PR DESCRIPTION
## Résumé
- retirer la mention du profil `export-to-server` dans le README

## Tests
- `mvn -q package` *(échoue : `mvn` non trouvé)*

------
https://chatgpt.com/codex/tasks/task_e_684f1ca276e8832e8bb67984b4001ecf