### PR TITLE
Corrige les dépendances de test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,17 @@
 
     <properties>
         <java.version>17</java.version>
-        <paper.api.version>1.20.4-R0.1-SNAPSHOT</paper.api.version>
+        <paper.api.version>1.20.6-R0.1-SNAPSHOT</paper.api.version>
     </properties>
 
     <repositories>
         <repository>
             <id>papermc</id>
             <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+        <repository>
+            <id>codemc</id>
+            <url>https://repo.codemc.io/repository/maven-public/</url>
         </repository>
     </repositories>
 
@@ -33,7 +37,7 @@
         </dependency>
         <dependency>
             <groupId>io.github.seeseemelk.mockbukkit</groupId>
-            <artifactId>mockbukkit-v1_20_R3</artifactId>
+            <artifactId>mockbukkit-v1_20_R4</artifactId>
             <version>2.46.0</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
## Notes
- `mvn` n’est pas disponible dans l’environnement, impossible de vérifier la compilation.

## Summary
- met à jour la version Paper API
- ajoute le dépôt CodeMC
- corrige l’artefact MockBukkit


------
https://chatgpt.com/codex/tasks/task_e_6850242aa554832e85e9ff1b5ba919ce