### PR TITLE
Corrige la dépendance MockBukkit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,10 @@
             <id>papermc</id>
             <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
+        <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -33,7 +37,7 @@
         </dependency>
         <dependency>
             <groupId>io.github.seeseemelk.mockbukkit</groupId>
-            <artifactId>mockbukkit-v1_20_R3</artifactId>
+            <artifactId>mockbukkit-v1_20_R4</artifactId>
             <version>2.46.0</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
## Summary
- utilise `mockbukkit-v1_20_R4`
- ajoute le dépôt Maven Central pour garantir la résolution des dépendances

## Testing
- `mvn -q package` *(échoue : `mvn` absent)*

------
https://chatgpt.com/codex/tasks/task_e_68503039a7dc832e9fbbe87cb7be3e08