### PR TITLE
Fixe orientation des poutres après rotation

### DIFF
--- a/src/main/java/org/example/Batiments.java
+++ b/src/main/java/org/example/Batiments.java
@@ -75,7 +75,12 @@ public final class Batiments {
                 boolean edge = dx == 0 || dx == width - 1 || dz == 0 || dz == depth - 1;
                 if (!edge) continue;
                 int[] p = rotate(dx, dz, rotationDeg);
-                final boolean eastWest = dz == 0 || dz == depth - 1;
+                BlockFace baseDir = (dz == 0) ? BlockFace.NORTH :
+                        (dz == depth - 1) ? BlockFace.SOUTH :
+                                (dx == 0) ? BlockFace.WEST : BlockFace.EAST;
+                BlockFace outward = rotFace(baseDir, rotationDeg);
+                final boolean eastWest =
+                        outward == BlockFace.NORTH || outward == BlockFace.SOUTH;
                 res.add(() -> {
                     ctx.setBlockTracked(w, ox + p[0], beamY, oz + p[1], logMat);
                     /* petite orientation de l’écorce pour que les fibres suivent l’arête */


### PR DESCRIPTION
## Notes
Maven n'est pas disponible dans l'environnement, la compilation n'a pas pu être vérifiée.

## Summary
- calcule l'orientation des poutres après rotation en utilisant la direction tournée

## Testing
- `mvn -q package` *(échoue: commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6850886e9b34832e9aaf67188dc77a86