### PR TITLE
Ajout porte orientée

### DIFF
--- a/src/main/java/org/example/Batiments.java
+++ b/src/main/java/org/example/Batiments.java
@@ -4,6 +4,8 @@ import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.Orientable;
+import org.bukkit.block.data.Bisected;
+import org.bukkit.block.data.type.Door;
 import org.bukkit.block.data.type.Stairs;
 import org.bukkit.entity.EntityType;
 
@@ -139,8 +141,15 @@ public final class Batiments {
 
         /* ---------- porte + lanterne de façade ---------- */
         int[] doorRel = rotate(width / 2, 0, rotationDeg);
-        res.add(() -> ctx.setBlockTracked(w, ox + doorRel[0], oy + 1, oz + doorRel[1], doorMat));
-        res.add(() -> ctx.setBlockTracked(w, ox + doorRel[0], oy + 2, oz + doorRel[1], doorMat));
+        BlockFace outward = rotFace(BlockFace.NORTH, rotationDeg);
+        Door bottom = (Door) doorMat.createBlockData();
+        bottom.setFacing(outward);
+        bottom.setHalf(Bisected.Half.BOTTOM);
+        Door top = (Door) doorMat.createBlockData();
+        top.setFacing(outward);
+        top.setHalf(Bisected.Half.TOP);
+        res.add(() -> ctx.setBlockTracked(w, ox + doorRel[0], oy + 1, oz + doorRel[1], bottom));
+        res.add(() -> ctx.setBlockTracked(w, ox + doorRel[0], oy + 2, oz + doorRel[1], top));
         res.add(() -> ctx.setBlockTracked(w, ox + doorRel[0], oy + 3, oz + doorRel[1], Material.LANTERN));
 
         /* ---------- perron 2 × 2 ---------- */

--- a/src/main/java/org/example/Village.java
+++ b/src/main/java/org/example/Village.java
@@ -180,6 +180,12 @@ public final class Village implements CommandExecutor {
         placedBlocks.add(b.getLocation());
     }
 
+    public void setBlockTracked(World w, int x, int y, int z, BlockData data) {
+        Block b = w.getBlockAt(x, y, z);
+        b.setBlockData(data, false);
+        placedBlocks.add(b.getLocation());
+    }
+
     public Runnable createSpawnerAction(World w, int x, int y, int z, EntityType type) {
         return () -> {
             setBlockTracked(w, x, y, z, Material.SPAWNER);


### PR DESCRIPTION
## Notes
Maven n'est pas disponible dans l'environnement, la compilation n'a pas pu être testée.

## Summary
- ajoute la pose de `BlockData` dans `Village`
- oriente la porte des maisons dans `Batiments`


------
https://chatgpt.com/codex/tasks/task_e_6850893bc614832e84dafc23f3d62632