### PR TITLE
Corrige import manquant pour BlockData

### DIFF
--- a/src/main/java/org/example/Village.java
+++ b/src/main/java/org/example/Village.java
@@ -3,6 +3,7 @@ package org.example;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.CreatureSpawner;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;


### PR DESCRIPTION
## Notes
- Maven n'est pas disponible dans l'environnement; compilation non vérifiée.

## Summary
- ajoute l'import `BlockData` manquant dans `Village.java` pour permettre l'appel de `setBlockTracked` avec des données de bloc


------
https://chatgpt.com/codex/tasks/task_e_68508bfed730832e8f7e59e49b745abb