### PR TITLE
Applique la nouvelle initialisation du RanchSession

### DIFF
--- a/src/main/java/org/example/Eleveur.java
+++ b/src/main/java/org/example/Eleveur.java
@@ -526,16 +526,15 @@ public final class Eleveur implements CommandExecutor, Listener {
 
         RanchSession(JavaPlugin plugin, Location origin, int width, int length) {
             this.plugin = plugin;
+            this.animalLimit = plugin.getConfig().getInt("eleveur.animal-limit", 5);
+            this.ranchLoopPeriodTicks = plugin.getConfig()
+                    .getInt("eleveur.villager-restock-ticks", 40);
             this.world = origin.getWorld();
             this.baseX = origin.getBlockX();
             this.baseY = origin.getBlockY();
             this.baseZ = origin.getBlockZ();
             this.width = width;
             this.length = length;
-
-            this.animalLimit = plugin.getConfig().getInt("eleveur.animal-limit", 5);
-            this.ranchLoopPeriodTicks = plugin.getConfig()
-                    .getInt("eleveur.villager-restock-ticks", 40);
         }
 
         public void start() {


### PR DESCRIPTION
## Notes
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

## Summary
- déplace l'initialisation de `animalLimit` et `ranchLoopPeriodTicks` juste après l'assignation du plugin
- maintient l'usage de ces champs dans tout le déroulé du ranch

## Testing
- `mvn -q package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68517d0b6c54832e9af9bd13a6f288b4