### PR TITLE
Correctif zone de comptage

### DIFF
--- a/src/main/java/org/example/Eleveur.java
+++ b/src/main/java/org/example/Eleveur.java
@@ -893,7 +893,7 @@ public final class Eleveur implements CommandExecutor, Listener {
         private List<LivingEntity> getEntitiesInZone(EntityType type) {
             BoundingBox box = new BoundingBox(
                     baseX, baseY, baseZ,
-                    baseX + width, baseY + 10, baseZ + length
+                    baseX + width - 1 + 0.99, baseY + 10, baseZ + length - 1 + 0.99
             );
             return world.getNearbyEntities(box, e -> e.getType() == type)
                     .stream()


### PR DESCRIPTION
## Notes
- `mvn` est absent de l'environnement, la compilation n'a pas pu être vérifiée.

## Summary
- ajuste la taille de la BoundingBox pour compter tous les animaux

## Testing
- `mvn -q package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518d5ca9f0832eb6bcb67c855dd9cb