### PR TITLE
Ajout de rafraîchissement des trades

### DIFF
--- a/src/main/java/org/example/Eleveur.java
+++ b/src/main/java/org/example/Eleveur.java
@@ -556,6 +556,8 @@ public final class Eleveur implements CommandExecutor, Listener {
 
         // Index pour le round-robin des coffres
         private int lastChestIndex = 0;
+        // Compteur pour le rafraîchissement des trades
+        private int tradesCounter = 0;
 
         RanchSession(JavaPlugin plugin, Location origin, int width, int length) {
             this.plugin = plugin;
@@ -891,6 +893,13 @@ public final class Eleveur implements CommandExecutor, Listener {
                     // Transférer inventaire PNJ vers coffres
                     if (rancher != null) {
                         transferPNJInventory();
+                        tradesCounter += ranchLoopPeriodTicks;
+                        if (tradesCounter >= 20 * 60) {
+                            if (rancher != null && !rancher.isDead()) {
+                                setupTrades(rancher);
+                            }
+                            tradesCounter = 0;
+                        }
                     }
                 }
             };


### PR DESCRIPTION
## Notes
Maven n'est pas installé dans l'environnement.

## Summary
- ajoute un compteur `tradesCounter` dans `RanchSession`
- rafraîchit périodiquement les offres du PNJ dans `runRanchLoop`

## Testing
- `mvn -q package` *(échec : mvn absent)*

------
https://chatgpt.com/codex/tasks/task_e_685196c74aa8832ea33d2c14dc0df2c6