### PR TITLE
Add campfire check to RanchSession

### DIFF
--- a/src/main/java/org/example/Eleveur.java
+++ b/src/main/java/org/example/Eleveur.java
@@ -578,6 +578,7 @@ public final class Eleveur implements CommandExecutor, Listener {
             buildWalls();
             buildGround();
             applyPath();   // Chemin central
+            ensureCampfire();
             buildRoof();   // Petit toit décoratif
 
             placeChests();
@@ -724,6 +725,20 @@ public final class Eleveur implements CommandExecutor, Listener {
                         lamp.setType(Material.LANTERN);
                     }
                 }
+            }
+        }
+
+        /**
+         * Assure la présence d'un feu de camp au centre.
+         * Place un HAY_BLOCK en support si besoin.
+         */
+        private void ensureCampfire() {
+            int cx = baseX + width / 2;
+            int cz = baseZ + length / 2;
+            Block campfire = world.getBlockAt(cx, baseY + 1, cz);
+            if (campfire.getType() != Material.CAMPFIRE) {
+                setBlock(cx, baseY, cz, Material.HAY_BLOCK);
+                campfire.setType(Material.CAMPFIRE);
             }
         }
 


### PR DESCRIPTION
## Summary
- ensure a campfire exists in the centre of a ranch
- place hay block underneath if missing

## Testing
- `mvn -q package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851997c3238832eb1e663b8d24ff619