### PR TITLE
Corrige concaténation ChatColor/int

### DIFF
--- a/src/main/java/org/example/Eleveur.java
+++ b/src/main/java/org/example/Eleveur.java
@@ -182,7 +182,7 @@ public final class Eleveur implements CommandExecutor, Listener {
         for (int i = 0; i < sessions.size(); i++) {
             RanchSession rs = sessions.get(i);
             Location o = rs.getOrigin();
-            String msg = ChatColor.AQUA + i + " : (" + o.getBlockX() + ", "
+            String msg = ChatColor.AQUA + "" + i + " : (" + o.getBlockX() + ", "
                     + o.getBlockY() + ", " + o.getBlockZ() + ")";
             player.sendMessage(msg);
         }


### PR DESCRIPTION
## Notes
- Maven n'est pas installé dans l'environnement, la compilation n'a pas pu être vérifiée.

## Résumé
- force la conversion en chaîne pour l'affichage des enclos dans `listSessions`

------
https://chatgpt.com/codex/tasks/task_e_6851d42fa27c832e91770c33b62a3447