### PR TITLE
Ajout utilitaire paintStrip

### DIFF
--- a/src/main/java/org/example/village/Disposition.java
+++ b/src/main/java/org/example/village/Disposition.java
@@ -61,10 +61,9 @@ public final class Disposition {
 
                 /* 1) bande de route (axe N‑S) */
                 int roadX = baseX;
-                for (int dz = -roadHalf; dz <= roadHalf; dz++) {
-                    int z = baseZ + dz;
-                    HouseBuilder.paintRoad(q, roadPalette, roadX, baseY, z, sb);
-                }
+                HouseBuilder.paintStrip(q, roadPalette,
+                        roadX, baseY,
+                        baseZ - roadHalf, baseZ + roadHalf, sb);
 
                 /* 2) choix bâtiment sur le lot */
                 int lotX = baseX - lotW / 2;

--- a/src/main/java/org/example/village/HouseBuilder.java
+++ b/src/main/java/org/example/village/HouseBuilder.java
@@ -113,6 +113,25 @@ public final class HouseBuilder {
     }
 
     /* -------------------------------------------------------------- */
+    /*  util : bande verticale de route                                */
+    /* -------------------------------------------------------------- */
+    public static void paintStrip(Queue<Runnable> q,
+                                  List<Material> palette,
+                                  int fx, int fy,
+                                  int fz0, int fz1,
+                                  TerrainManager.SetBlock sb) {
+
+        Random R = new Random();
+        int minZ = Math.min(fz0, fz1);
+        int maxZ = Math.max(fz0, fz1);
+        for (int z = minZ; z <= maxZ; z++) {
+            final int fz = z;
+            Material m = palette.get(R.nextInt(palette.size()));
+            q.add(() -> sb.set(fx, fy, fz, m));
+        }
+    }
+
+    /* -------------------------------------------------------------- */
     /* CHAMP (farmland + eau + cultures)                              */
     /* -------------------------------------------------------------- */
     public static List<Runnable> buildFarm(Location base,


### PR DESCRIPTION
## Notes
Maven absent dans l'environnement, impossible de vérifier la compilation.

## Summary
- ajoute `paintStrip` pour tracer une bande de route verticale
- simplifie la construction des routes en utilisant `paintStrip`

## Testing
- `mvn -q package` *(échoue : command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851fdc16600832ea95e4e5c23d5ff6d