### PR TITLE
Appliquer PATCH 6 sur la distribution des spawners

### DIFF
--- a/src/main/java/org/example/Batiments.java
+++ b/src/main/java/org/example/Batiments.java
@@ -27,7 +27,8 @@ public final class Batiments {
             World w, Location start,
             int width, int depth,
             int rotationDeg,
-            Village ctx) {
+            Village ctx,
+            boolean habitation) {
 
         List<Runnable> res = new ArrayList<>();
         int ox = start.getBlockX();
@@ -175,7 +176,7 @@ public final class Batiments {
 
         /* ---------- éventuel spawner PNJ ---------- */
         int[] center = rotate(width / 2, depth / 2, rotationDeg);
-        if (ctx.shouldPlaceSpawner()) {
+        if (habitation && ctx.shouldPlaceSpawner()) {
             res.add(ctx.createSpawnerAction(
                     w, ox + center[0], oy + 1, oz + center[1],
                     EntityType.VILLAGER));

--- a/src/main/java/org/example/Village.java
+++ b/src/main/java/org/example/Village.java
@@ -40,7 +40,7 @@ public final class Village implements CommandExecutor {
 
     public void prepareVillagerSpawnerDistribution(int totalHouses) {
         int quota = Math.min(MAX_VIL_SPAWNERS,
-                Math.max(MIN_VIL_SPAWNERS, totalHouses / 3));
+                Math.max(MIN_VIL_SPAWNERS, totalHouses / 2));
         Set<Integer> chosen = new HashSet<>();
         while (chosen.size() < quota) chosen.add(rng.nextInt(totalHouses));
         villagerSpawnerIdx = chosen;
@@ -136,9 +136,12 @@ public final class Village implements CommandExecutor {
 
                 int rot = computeHouseRotation(hx, hz, center);
 
+                double roll = rng.nextDouble();
+                boolean habitation = roll < 0.70;           // lot = house small|big
+
                 todo.addAll(Batiments.buildHouseRotatedActions(
                         w, new Location(w, hx, baseY, hz),
-                        houseW, houseD, rot, this));
+                        houseW, houseD, rot, this, habitation));
             }
         }
 


### PR DESCRIPTION
## Summary
- ajuster la répartition des spawners de villageois
- transmettre l'information d'habitation pour les lots
- poser un spawner PNJ seulement dans les habitations

## Testing
- `mvn -q package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685213d34344832e998a4c5c2de0ca06