### PR TITLE
Ajout de WALL_GAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ Il rassemble différents paramètres du plugin que vous pouvez ajuster :
 - le prix en émeraudes des piles de viande vendues par le PNJ ;
 - la chance d'obtenir de la viande cuite.
 - la taille des maisons et la grille du village pour la commande `/village`.
+- la marge par défaut de six blocs autour de la muraille du village.
 
 La section `village` du fichier YAML contient notamment `houseSmall`,
-`houseBig`, `roadHalf`, `spacing`, `plazaSize`, `rows` et `cols` pour
+`houseBig`, `roadHalf`, `spacing`, `plazaSize`, `rows`, `cols` et `wallGap` pour
 personnaliser la génération du village.
 
 Le fichier de référence se trouve dans `src/main/resources/config.yml`. Modifiez

--- a/src/main/java/org/example/Village.java
+++ b/src/main/java/org/example/Village.java
@@ -31,6 +31,7 @@ public final class Village implements CommandExecutor {
     private static final int MAX_VIL_SPAWNERS = 8;
     private static final int GOLEM_SPAWNERS   = 2;          // au moins 2 générateurs de golems
     private static final int NPC_CAP          = 100;        // plafond mou pour limiter le lag
+    private static final int WALL_GAP         = 6;          // distance entre les maisons et la muraille
     /* ──────────────────────────────────────────────────────────── */
 
     private final Random rng = new Random();
@@ -160,8 +161,8 @@ public final class Village implements CommandExecutor {
 
         /* muraille périphérique */
         todo.addAll(buildWallActions(w,
-                bounds[0] - 5, bounds[1] + 5,
-                bounds[2] - 5, bounds[3] + 5,
+                bounds[0] - WALL_GAP, bounds[1] + WALL_GAP,
+                bounds[2] - WALL_GAP, bounds[3] + WALL_GAP,
                 baseY));
 
         /* maire + spawners à golem */

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -24,3 +24,4 @@ village:
   plazaSize: 9
   rows: 4
   cols: 5
+  wallGap: 6        # marge entre les maisons et la muraille


### PR DESCRIPTION
## Notes
- `mvn` n'est pas disponible dans l'environnement.

## Summary
- ajoute la constante `WALL_GAP` dans `Village.java`
- applique cette marge lors de la construction de la muraille
- documente la marge par défaut dans `README.md` et `config.yml`

## Testing
- `mvn -q package` *(échoue : command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68521a217c44832e9fb9bbcabe6e3b27