### PR TITLE
Ajoute la gestion de la colère du golem

### DIFF
--- a/src/main/java/org/example/Golem.java
+++ b/src/main/java/org/example/Golem.java
@@ -5,9 +5,14 @@ import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.IronGolem;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
+import java.lang.reflect.Method;
 
 /**
  * Golem sentinelle.
+ *
+ * <p>Depuis Paper 1.20, {@link IronGolem} possède une méthode
+ * {@code setAnger(int)}. Lorsque disponible, le constructeur l’utilise
+ * pour appliquer 600 ticks de colère (30 s).</p>
  */
 public final class Golem {
 
@@ -40,6 +45,14 @@ public final class Golem {
             g.setCustomNameVisible(true);
             g.setPlayerCreated(true);
             // ↑ non‑hostile envers les joueurs
+
+            // 30 s de colère si la méthode existe (Paper 1.20+)
+            try {
+                Method m = g.getClass().getMethod("setAnger", int.class);
+                m.invoke(g, 600);
+            } catch (NoSuchMethodException ignored) {
+            } catch (Exception ignored) {
+            }
 
             // Vitesse 0.35 si l’attribut existe sur la version courante
             if (g.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED) != null) {


### PR DESCRIPTION
## Notes
- Maven est indisponible dans l’environnement de CI.

## Summary
- initialise la colère du golem via `setAnger` quand disponible
- documente cette particularité pour Paper 1.20+

## Testing
- `mvn -q package` *(échoue: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533444c80c832e94162beedce2a111