### PR TITLE
Évite crash lorsque plus de coffres disponibles

### DIFF
--- a/src/main/java/org/example/Mineur.java
+++ b/src/main/java/org/example/Mineur.java
@@ -651,7 +651,9 @@ public class Mineur implements CommandExecutor, Listener {
         private void depositDrops(List<ItemStack> drops, int chestIndex) {
             if (drops.isEmpty() || chestBlocks.isEmpty() || miner == null || miner.isDead()) return;
 
-            Block chestBlock = chestBlocks.get(chestIndex % chestBlocks.size());
+            int size = chestBlocks.size();
+            if (size == 0) return;
+            Block chestBlock = chestBlocks.get(chestIndex % size);
             Location dest = chestBlock.getLocation().add(0.5, 1.0, 0.5);
 
             boolean moved = false;


### PR DESCRIPTION
## Summary
- ajoute un contrôle de taille dans `depositDrops` pour éviter une `ArithmeticException`

## Testing
- `mvn -q package` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685340195544832e83bebe752c8f7cce